### PR TITLE
Move "..." button to bottom-center; improve how tooltips are suppressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,19 @@ When this happens, ideally, someone will push an update to this repository with 
 
 After that's been done, your Stylus extension should automatically obtain and apply the updates from the [userstyles.world mirror](https://userstyles.world/style/15633/ae-jira-kanban) -- no need for you to take any manual action!
 
-### Specific Improvements (as of v1.0.3)
+### Specific Improvements (as of v1.0.5)
 
 - Card titles are no longer truncated!
 - Removes on-hover card title tool tips. (No longer needed now that titles aren't truncated!)
-- Uses the full card width when displaying card titles
-- Moves each card's `...` on-hover button to the bottom-left corner (to avoid obscuring card titles)
-- Slightly increases card and column width
-- Reduces unneeded vertical whitespace in the top header portion of the board
-- Increases the column header font size
-- Slightly reduces vertical whitespace in the column header row
-- Replaces the default green "Task" card type icon (which looks very similar to the green "Story" card type icon) with an orange square icon
-- Displays due dates in red
+- Also removes on-hover tool tips for card Epic labels, and card IDs. 
+- Uses the full card width when displaying card titles.
+- Moves each card's `...` on-hover button to the bottom-center (to reduce obscuring of other card elements).
+- Slightly increases card and column width.
+- Reduces unneeded vertical whitespace in the top header portion of the board.
+- Increases the column header font size.
+- Slightly reduces vertical whitespace in the column header row.
+- Replaces the default green "Task" card type icon (which looks very similar to the green "Story" card type icon) with an orange square icon.
+- Displays due dates in red.
 
 ### How To Contribute
 

--- a/ae_jira_kanban.user.css
+++ b/ae_jira_kanban.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           ae_jira_kanban
 @namespace      github.com/openstyles/stylus
-@version        1.0.4
+@version        1.0.5
 @description    Make the Jira Kanban board more pleasant to use
 @author         ae_jira_kanban Team
 @homepageURL    https://github.com/appfolio/ae_userstyles
@@ -20,7 +20,7 @@
         margin-bottom: 2px;
     }
 
-    /* Top nav row with search field, partipant icons, "Epic" and other dropdowns - Reduce vertical whitespace */
+    /* Top nav row with search field, participant icons, "Epic" and other dropdowns - Reduce vertical whitespace */
     ._otyrxy5q {
         margin-bottom: 5px;
     }
@@ -29,49 +29,54 @@
     [data-testid="platform-board-kit.common.ui.column-header.header.column-header-container"] {
         height: 30px;
     }
-       
+
     /* Column headers - Increase font size/weight */
     h2.__board-test-hook__column-title {
         font-weight: 600;
         font-size: 15px;
     }
-    
+
     /* Column header div - Increase card and column width */
     div[data-component-selector="platform-board-kit.ui.column.draggable-column"] {
         min-width: 290px;
-        margin-right: 8px; /* Add a little spacing betweeen columns */
+        margin-right: 8px;
     }
-    
+
     /* Card div - Slightly reduce vertical whitespace content padding */
     .yse7za_content {
         padding-top: 3px;
         padding-bottom: 6px;
     }
-    
+
     /* Card title text spans */
     ._slp31hna {
-        padding-right: 0px; /* Allow card title to span full card width */
+        padding-right: 0; /* Allow card title to span full card width */
         -webkit-line-clamp: 7; /* Discontinue truncation of card titles (<= 7 lines) */
-    }
-    
-    /* Card on-hover tool tips - Remove. (Unneeded now that we're preventing truncation of card titles!) */
-    .Tooltip.css-1kad8p3 {
-        display: none;
+        pointer-events: none; /* Card title on-hover tool tips: remove. (Unneeded now that we're preventing truncation of card titles!) */
     }
 
-    /* Card "..." on-hover button - Move to lower-left of card (to avoid obscuring card title on hover) */
-    [data-test-id="platform-card.ui.card.actions-section"] {
-        top: initial;
-        right: initial;
-        bottom: var(--ds-space-100);
-        left: var(--ds-space-100);
+    /* Card ID labels (in the bottom left of each card) */
+    ._p12f1osq {
+        pointer-events: none; /* Card ID tool tips: remove */
     }
-    
+
+    /* Card Epic labels (with colored background, below the card title text) */
+    ._1reo15vq {
+        pointer-events: none; /* Card Epic label tool tips: remove */
+    }
+
+    /* Card "..." on-hover button - Move to bottom-center of card (to avoid obscuring other card elements on hover) */
+    [data-testid="platform-card.ui.card.actions-section"] {
+        top: initial;
+        right: 123px;
+        bottom: 5px;
+    }
+
     /* Replace the "task" card type icon with an orange box */
     img[src="https://appfolio.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10311?size=medium"] {
         content: url('https://placehold.co/20x20/orange/orange')
     }
-    
+
     /* Color due dates red */
     div[data-issuefieldid="duedate"] {
         color: #f00;


### PR DESCRIPTION
- Due to a bug in the prior version (use of "data-test-id" instead of "data-testid"), the "..." button was appearing in the top-right corner (the default behavior), which caused the card title to be partially obscured when the mouse cursor was hovered over the card
- The "..." button now attempts to be placed in the bottom-center of the card, to the left of the "pull request status", "card age (horizontal dots)", "priority", and "assignee" icons. The card-coded "right" value assumes those icons are ALL being displayed, and the maximum of 4 horizontal dots are being displayed.
- The previous strategy for suppressing tool tips -- setting the tool tip CSS class itself to "display: none" -- was flaky: The tool tip would often flash visible briefly before being suppressed. This is replaced with use of "pointer-events: none", which prevents the JavaScript from adding the tooltip element to the DOM in the first place; with the result being that the briefly visible flash of the tool tip no longer occurs.
- The tool tips for the "card age" and "assignee" icons are now no longer suppressed (since those are actually useful).