### PR TITLE
[PAYLOR-1653] Hide drag-drop column overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ When this happens, ideally, someone will push an update to this repository with 
 
 After that's been done, your Stylus extension should automatically obtain and apply the updates from the [userstyles.world mirror](https://userstyles.world/style/15633/ae-jira-kanban) -- no need for you to take any manual action!
 
-### Specific Improvements (as of v1.0.7)
+### Specific Improvements (as of v1.0.8)
 
 - Card titles are no longer truncated!
 - Removes on-hover card title tool tips. (No longer needed now that titles aren't truncated!)
 - Also removes on-hover tool tips for card Epic labels, and card IDs. 
 - Uses the full card width when displaying card titles.
 - Moves each card's `...` on-hover button to the bottom-center (to reduce obscuring of other card elements).
+- Hides the drag-drop column overlays (introduced ~June 2025) that obscure the ordering position in the destination column.
 - Slightly increases card and column width.
 - Reduces unneeded vertical whitespace in the top header portion of the board.
 - Increases the column header font size.
@@ -76,4 +77,4 @@ Alternatively (if you aren't using it for anything else): Just disable or uninst
 
 - Julie DeMello, for contributing some of the original CSS!
 - Seth VanBrocklin and Dean Johnson, for contributing to the project launch!
-- AppFolio leadership, for continuing to sponsor Hack Days, without which this project would not exist!
+- AppFolio leadership, for continuing to sponsor Hack Days and Impact Fridays, without which this project would not exist!

--- a/ae_jira_kanban.user.css
+++ b/ae_jira_kanban.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           ae_jira_kanban
 @namespace      github.com/openstyles/stylus
-@version        1.0.7
+@version        1.0.8
 @description    Make the Jira Kanban board more pleasant to use
 @author         ae_jira_kanban Team
 @homepageURL    https://github.com/appfolio/ae_userstyles
@@ -94,5 +94,10 @@
     /* Color due dates red */
     div[data-issuefieldid="duedate"] {
         color: #f00;
+    }
+
+    /* Hide the drag-drop column overlays (introduced ~June 2025) that obscure the ordering position in the destination column */
+    div[data-component-selector="platform-board-kit.ui.column.column-transition-zones-container.outer-transition-container"] {
+        display: none;
     }
 }


### PR DESCRIPTION
Hides the drag-drop column overlays (introduced ~June 2025) that obscure the ordering position in the destination column.