### PR TITLE
Fix problem where could not drop cards into empty coluns

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ When this happens, ideally, someone will push an update to this repository with 
 
 After that's been done, your Stylus extension should automatically obtain and apply the updates from the [userstyles.world mirror](https://userstyles.world/style/15633/ae-jira-kanban) -- no need for you to take any manual action!
 
-### Specific Improvements (as of v1.0.8)
+### Specific Improvements (as of v1.0.9)
 
 - Card titles are no longer truncated!
 - Removes on-hover card title tool tips. (No longer needed now that titles aren't truncated!)
 - Also removes on-hover tool tips for card Epic labels, and card IDs. 
 - Uses the full card width when displaying card titles.
 - Moves each card's `...` on-hover button to the bottom-center (to reduce obscuring of other card elements).
-- Hides the drag-drop column overlays (introduced ~June 2025) that obscure the ordering position in the destination column.
+- Moves to behind the cards the column overlays (introduced ~June 2025) that prevent setting the order of card position in the destination column during card drag-drop.
 - Slightly increases card and column width.
 - Reduces unneeded vertical whitespace in the top header portion of the board.
 - Increases the column header font size.

--- a/ae_jira_kanban.user.css
+++ b/ae_jira_kanban.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           ae_jira_kanban
 @namespace      github.com/openstyles/stylus
-@version        1.0.8
+@version        1.0.9
 @description    Make the Jira Kanban board more pleasant to use
 @author         ae_jira_kanban Team
 @homepageURL    https://github.com/appfolio/ae_userstyles
@@ -86,18 +86,18 @@
         bottom: 5px;
     }
 
-    /* Replace the "task" card type icon with an orange box */
-    img[src="https://appfolio.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10311?size=medium"] {
-        content: url('https://placehold.co/20x20/orange/orange')
-    }
-
-    /* Color due dates red */
-    div[data-issuefieldid="duedate"] {
-        color: #f00;
-    }
-
-    /* Hide the drag-drop column overlays (introduced ~June 2025) that obscure the ordering position in the destination column */
+    /* Move the drag-drop column overlays (introduced ~June 2025) that would prevent position ordering in the destination column to behind the cards */
+    /* The drag-drop column overlays */
     div[data-component-selector="platform-board-kit.ui.column.column-transition-zones-container.outer-transition-container"] {
-        display: none;
+        opacity: 0.5; 
+        z-index: 2;
+    }
+    /* The visbile-only-on-column-hover "+ Create" buttons */
+    ul[data-testid="software-board.board-container.board.virtual-board.fast-virtual-list.fast-virtual-list-wrapper"] > li:last-of-type {
+        z-index: 1; 
+    }
+    /* The cards */
+    div[data-testid="software-board.board-container.board.card-container.card-with-icc"] {
+        z-index: 3;
     }
 }


### PR DESCRIPTION
- Restores the drag-drop-target column overlays -- we need them to be able to drop cards into empty columns -- but moves them _behind_ the cards themselves, which allows drag-dropped cards to still be positioned in destination columns between (or before, or after) existing cards.
- Moves the column overlays on _top_ of the "+ Create" hidden buttons (so that there isn't a visible "gap" in at the top of each column overlay when they are visible during drag-drop operations) 
- Reduces the column overlays to 50% opacity, to make their appearance less jarring (and less prominent than the board's cards). 
  - Note: I also tested 0% opacity. While that works, it hurts UX by making it less obvious that empty areas of each column are valid drop targets.

Thanks to @Maimer for the bug report!