### PR TITLE
Fix bug where user assignment and options popovers were obscured

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When this happens, ideally, someone will push an update to this repository with 
 
 After that's been done, your Stylus extension should automatically obtain and apply the updates from the [userstyles.world mirror](https://userstyles.world/style/15633/ae-jira-kanban) -- no need for you to take any manual action!
 
-### Specific Improvements (as of v1.0.9)
+### Specific Improvements (as of v1.0.10)
 
 - Card titles are no longer truncated!
 - Removes on-hover card title tool tips. (No longer needed now that titles aren't truncated!)

--- a/ae_jira_kanban.user.css
+++ b/ae_jira_kanban.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           ae_jira_kanban
 @namespace      github.com/openstyles/stylus
-@version        1.0.9
+@version        1.0.10
 @description    Make the Jira Kanban board more pleasant to use
 @author         ae_jira_kanban Team
 @homepageURL    https://github.com/appfolio/ae_userstyles
@@ -87,17 +87,8 @@
     }
 
     /* Move the drag-drop column overlays (introduced ~June 2025) that would prevent position ordering in the destination column to behind the cards */
-    /* The drag-drop column overlays */
     div[data-component-selector="platform-board-kit.ui.column.column-transition-zones-container.outer-transition-container"] {
         opacity: 0.5; 
-        z-index: 2;
-    }
-    /* The visbile-only-on-column-hover "+ Create" buttons */
-    ul[data-testid="software-board.board-container.board.virtual-board.fast-virtual-list.fast-virtual-list-wrapper"] > li:last-of-type {
-        z-index: 1; 
-    }
-    /* The cards */
-    div[data-testid="software-board.board-container.board.card-container.card-with-icc"] {
-        z-index: 3;
+        z-index: 0;
     }
 }


### PR DESCRIPTION
The z-indexes applied in the previous version were causing card content menu popovers -- including the user assignee popover, and the "..." popover -- to appear underneath subsequent cards in the same column (if any).

This fixes the problem by removing the z-index values from everything except the column drag target regions.

Unfortunately this introduces a minor issue where the area that would be occupied by the "+ Create" button, under the last cardin each column, is not a valid drop target. Accepting this issue for now because it is more minor than the issue of the popover menus being mostly unusable.