### PR TITLE
Add CODEOWNERS and catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jschneid

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ae_userstyles
+  description: "CSS overrides to make the Jira Kanban view more pleasant to use"
+spec:
+  type: tool
+  lifecycle: stable
+  owner: CODEOWNERS


### PR DESCRIPTION
Adds `.github/CODEOWNERS` and `catalog-info.yaml` to register this repo in the Developer Portal.

Part of the repo ownership initiative: https://docs.google.com/spreadsheets/d/1sd6gorLtYuBb3W4JWK1R_K-PnSTmbTJoH27SQG1_8gU